### PR TITLE
Lanzar una excepción en caso de que un empleado en específico no posee información clínica

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Estos archivos no quiero que los envie
 
+.venv/
+
 main_bd1.py
 main_bd2.py
 main_bd3.py

--- a/repositorios/empleados/info_clinica_empleado_repositorio.py
+++ b/repositorios/empleados/info_clinica_empleado_repositorio.py
@@ -80,7 +80,12 @@ class InfoClinicaEmpleadoRepositorio(RepositorioBase):
                     """
                 ), {"empleado_id": empleado_id}).fetchall()
                 
+                if not(info_clinica_empleado):
+                    raise BaseDatosError("EMPLEADO_NO_TIENE_INFO_CLINICA", "Este empleado no posee información clínica.")
+                
                 return info_clinica_empleado
+        except BaseDatosError as error:
+            raise error
         except Exception as error:
             print(f"ERROR AL OBTENER LA INFO CLÍNICA DEL EMPLEADO: {error}")
     

--- a/servicios/empleados/info_clinica_empleado_servicio.py
+++ b/servicios/empleados/info_clinica_empleado_servicio.py
@@ -18,7 +18,10 @@ class InfoClinicaEmpleadoServicio:
         return self.repositorio.obtener_por_id(info_clin_empleado_id)
     
     def obtener_info_clinica_por_empleado_id(self, empleado_id: int) -> List[Tuple]:
-        return self.repositorio.obtener_por_empleado_id(empleado_id)
+        try:
+            return self.repositorio.obtener_por_empleado_id(empleado_id)
+        except BaseDatosError as error:
+            raise error
     
     def actualizar_info_clinica(self, info_clin_empleado_id: int, campos_info_clinica_empleado: Dict) -> None:
         self.repositorio.actualizar(info_clin_empleado_id, campos_info_clinica_empleado)
@@ -66,3 +69,9 @@ if __name__ == "__main__":
     info_clinica_empleado_servicio.actualizar_info_clinica(3, campos_info_clinica_empleado)"""
     
     #info_clinica_empleado_servicio.eliminar_info_clinica(3)
+    
+    
+    """try:
+        print(info_clinica_empleado_servicio.obtener_info_clinica_por_empleado_id(2))
+    except BaseDatosError as error:
+        print(error)"""


### PR DESCRIPTION
Se lanza una excepción de tipo BaseDatosError con el mensaje correspondiente en caso de que un empleado no tenga información clínica.

Dado que lanza un mensaje en caso de que ocurra esa excepción como sugerencia puede capturarse ese mensaje y utilizarlo para incrustarlo en la debida sección de la información clínica de aquellos que no la posean.